### PR TITLE
fixes #5, adds use of DelegatedTo, tests and minor typos conrrections

### DIFF
--- a/src/main/groovy/org/asciidoctor/groovydsl/AsciidoctorExtensionHandler.groovy
+++ b/src/main/groovy/org/asciidoctor/groovydsl/AsciidoctorExtensionHandler.groovy
@@ -15,6 +15,14 @@
  */
 package org.asciidoctor.groovydsl
 
+import org.asciidoctor.extension.BlockMacroProcessor
+import org.asciidoctor.extension.BlockProcessor
+import org.asciidoctor.extension.DocinfoProcessor
+import org.asciidoctor.extension.IncludeProcessor
+import org.asciidoctor.extension.InlineMacroProcessor
+import org.asciidoctor.extension.Postprocessor
+import org.asciidoctor.extension.Preprocessor
+import org.asciidoctor.extension.Treeprocessor
 import org.asciidoctor.groovydsl.extensions.DelegatingBlockMacroProcessor
 import org.asciidoctor.groovydsl.extensions.DelegatingBlockProcessor
 import org.asciidoctor.groovydsl.extensions.DelegatingDocinfoProcessor
@@ -34,16 +42,16 @@ class AsciidoctorExtensionHandler {
     private static final String OPTION_CONTEXTS = 'contexts'
 
     private final Asciidoctor asciidoctor
-    
+
     AsciidoctorExtensionHandler(Asciidoctor asciidoctor) {
         this.asciidoctor = asciidoctor
     }
-    
-    void block(String blockName, Closure cl) {
+
+    void block(String blockName, @DelegatesTo(BlockProcessor) Closure cl) {
         block([(OPTION_NAME): blockName], cl)
     }
 
-    void block(Map options=[:], Closure cl) {
+    void block(Map options=[:], @DelegatesTo(BlockProcessor) Closure cl) {
         if (!options.containsKey(OPTION_NAME)) {
             throw new IllegalArgumentException('Block must define a name!')
         }
@@ -54,37 +62,37 @@ class AsciidoctorExtensionHandler {
         asciidoctor.javaExtensionRegistry().block(new DelegatingBlockProcessor(options, cl))
     }
 
-    void block_macro(Map options, Closure cl) {
+    void block_macro(Map options, @DelegatesTo(BlockMacroProcessor) Closure cl) {
         asciidoctor.javaExtensionRegistry().blockMacro(new DelegatingBlockMacroProcessor(options[OPTION_NAME], options, cl))
     }
 
-    void block_macro(String name, Closure cl) {
-        blockMacro([OPTION_NAME: name], cl)
+    void block_macro(String name, @DelegatesTo(BlockMacroProcessor) Closure cl) {
+        block_macro([(OPTION_NAME): name], cl)
     }
 
     /**
      * @deprecated Please use {@link #block_macro(java.util.Map, groovy.lang.Closure)} instead
      */
-    void blockmacro(Map options, Closure cl) {
-        asciidoctor.javaExtensionRegistry().blockMacro(new DelegatingBlockMacroProcessor(options[OPTION_NAME], options, cl))
+    void blockmacro(Map options, @DelegatesTo(BlockMacroProcessor) Closure cl) {
+        block_macro(options, cl)
     }
 
     /**
      * @deprecated Please use {@link #block_macro(java.lang.String, groovy.lang.Closure)} instead
      */
-    void blockmacro(String name, Closure cl) {
-        blockMacro([OPTION_NAME: name], cl)
+    void blockmacro(String name, @DelegatesTo(BlockMacroProcessor) Closure cl) {
+        block_macro([(OPTION_NAME): name], cl)
     }
 
-    void postprocessor(Map options=[:], Closure cl) {
+    void postprocessor(Map options=[:], @DelegatesTo(Postprocessor) Closure cl) {
         asciidoctor.javaExtensionRegistry().postprocessor(new DelegatingPostprocessor(options, cl))
     }
 
-    void preprocessor(Map options=[:], Closure cl) {
+    void preprocessor(Map options=[:], @DelegatesTo(Preprocessor) Closure cl) {
         asciidoctor.javaExtensionRegistry().preprocessor(new DelegatingPreprocessor(options, cl))
     }
 
-    void include_processor(Map options=[:], Closure cl) {
+    void include_processor(Map options=[:], @DelegatesTo(IncludeProcessor) Closure cl) {
         Closure filter = options[OPTION_FILTER]
         Map optionsWithoutFilter = options - options.subMap([OPTION_FILTER])
         asciidoctor.javaExtensionRegistry().includeProcessor(new DelegatingIncludeProcessor(optionsWithoutFilter, filter, cl))
@@ -93,39 +101,39 @@ class AsciidoctorExtensionHandler {
     /**
      * @deprecated Please use {@link #include_processor(java.util.Map, groovy.lang.Closure)} instead
      */
-    void includeprocessor(Map options=[:], Closure cl) {
-        Closure filter = options[OPTION_FILTER]
+    void includeprocessor(Map options=[:], @DelegatesTo(IncludeProcessor) Closure cl) {
+        Closure filter = options[(OPTION_FILTER)]
         Map optionsWithoutFilter = options - options.subMap([OPTION_FILTER])
         asciidoctor.javaExtensionRegistry().includeProcessor(new DelegatingIncludeProcessor(optionsWithoutFilter, filter, cl))
     }
 
-    void inline_macro(Map options, Closure cl) {
+    void inline_macro(Map options, @DelegatesTo(InlineMacroProcessor) Closure cl) {
         asciidoctor.javaExtensionRegistry().inlineMacro(new DelegatingInlineMacroProcessor(options[OPTION_NAME], options, cl))
     }
 
-    void inline_macro(String macroName, Closure cl) {
-        inlineMacro([OPTION_NAME: macroName], closure: cl)
+    void inline_macro(String macroName, @DelegatesTo(InlineMacroProcessor) Closure cl) {
+        inline_macro([(OPTION_NAME): macroName], cl)
     }
 
     /**
      * @deprecated Please use {@link #inline_macro(java.util.Map, groovy.lang.Closure)} instead
      */
-    void inlinemacro(Map options, Closure cl) {
+    void inlinemacro(Map options, @DelegatesTo(InlineMacroProcessor) Closure cl) {
         asciidoctor.javaExtensionRegistry().inlineMacro(new DelegatingInlineMacroProcessor(options[OPTION_NAME], options, cl))
     }
 
     /**
      * @deprecated Please use {@link #inline_macro(java.lang.String, groovy.lang.Closure)} instead
      */
-    void inlinemacro(String macroName, Closure cl) {
-        inlineMacro([OPTION_NAME: macroName], closure: cl)
+    void inlinemacro(String macroName, @DelegatesTo(InlineMacroProcessor) Closure cl) {
+        inline_macro([(OPTION_NAME): macroName], cl)
     }
 
-    void treeprocessor(Map options=[:], Closure cl) {
+    void treeprocessor(Map options=[:], @DelegatesTo(Treeprocessor) Closure cl) {
         asciidoctor.javaExtensionRegistry().treeprocessor(new DelegatingTreeprocessor(options, cl))
     }
 
-    void docinfo_processor(Map options=[:], Closure cl) {
+    void docinfo_processor(Map options=[:], @DelegatesTo(DocinfoProcessor) Closure cl) {
         asciidoctor.javaExtensionRegistry().docinfoProcessor(new DelegatingDocinfoProcessor(options, cl))
     }
 

--- a/src/main/groovy/org/asciidoctor/groovydsl/AsciidoctorExtensions.groovy
+++ b/src/main/groovy/org/asciidoctor/groovydsl/AsciidoctorExtensions.groovy
@@ -32,7 +32,7 @@ class AsciidoctorExtensions {
     // is asked to register its extensions
     static final List<Object> REGISTERED_EXTENSIONS = []
 
-    static void extensions(Closure cl) {
+    static void extensions(@DelegatesTo(AsciidoctorExtensionHandler) Closure cl) {
         REGISTERED_EXTENSIONS << cl
     }
 

--- a/src/main/groovy/org/asciidoctor/groovydsl/extensions/DelegatingBlockMacroProcessor.groovy
+++ b/src/main/groovy/org/asciidoctor/groovydsl/extensions/DelegatingBlockMacroProcessor.groovy
@@ -22,7 +22,7 @@ class DelegatingBlockMacroProcessor extends BlockMacroProcessor {
 
     private final Closure cl
 
-    DelegatingBlockMacroProcessor(String name, Map options, Closure cl) {
+    DelegatingBlockMacroProcessor(String name, Map options, @DelegatesTo(BlockMacroProcessor) Closure cl) {
         super(name, options)
         this.cl = cl
         cl.delegate = this

--- a/src/main/groovy/org/asciidoctor/groovydsl/extensions/DelegatingBlockProcessor.groovy
+++ b/src/main/groovy/org/asciidoctor/groovydsl/extensions/DelegatingBlockProcessor.groovy
@@ -20,12 +20,11 @@ import org.asciidoctor.extension.BlockProcessor
 import org.asciidoctor.extension.Reader
 import org.asciidoctor.groovydsl.AsciidoctorExtensionHandler
 
-
 class DelegatingBlockProcessor extends BlockProcessor {
 
     Closure cl
-    
-    DelegatingBlockProcessor(Map<String, Object> attributes, Closure cl) {
+
+    DelegatingBlockProcessor(Map<String, Object> attributes, @DelegatesTo(BlockProcessor) Closure cl) {
         super(attributes[AsciidoctorExtensionHandler.OPTION_NAME], attributes)
         this.cl = cl
         cl.delegate = this

--- a/src/main/groovy/org/asciidoctor/groovydsl/extensions/DelegatingDocinfoProcessor.groovy
+++ b/src/main/groovy/org/asciidoctor/groovydsl/extensions/DelegatingDocinfoProcessor.groovy
@@ -22,7 +22,7 @@ class DelegatingDocinfoProcessor extends DocinfoProcessor {
 
     final Closure cl
 
-    DelegatingDocinfoProcessor(Map options, Closure cl) {
+    DelegatingDocinfoProcessor(Map options, @DelegatesTo(DocinfoProcessor) Closure cl) {
         super(options)
         this.cl = cl
         cl.delegate = this

--- a/src/main/groovy/org/asciidoctor/groovydsl/extensions/DelegatingIncludeProcessor.groovy
+++ b/src/main/groovy/org/asciidoctor/groovydsl/extensions/DelegatingIncludeProcessor.groovy
@@ -24,7 +24,7 @@ class DelegatingIncludeProcessor extends IncludeProcessor {
     private final Closure filter
     private final Closure cl
 
-    DelegatingIncludeProcessor(Map options, Closure filter, Closure cl) {
+    DelegatingIncludeProcessor(Map options, Closure filter, @DelegatesTo(IncludeProcessor) Closure cl) {
         super(options)
         this.filter = filter
         this.cl = cl

--- a/src/main/groovy/org/asciidoctor/groovydsl/extensions/DelegatingInlineMacroProcessor.groovy
+++ b/src/main/groovy/org/asciidoctor/groovydsl/extensions/DelegatingInlineMacroProcessor.groovy
@@ -22,7 +22,7 @@ class DelegatingInlineMacroProcessor extends InlineMacroProcessor {
 
     private final Closure cl
 
-    DelegatingInlineMacroProcessor(String name, Map options, Closure cl) {
+    DelegatingInlineMacroProcessor(String name, Map options, @DelegatesTo(InlineMacroProcessor) Closure cl) {
         super(name, options)
         this.cl = cl
         cl.delegate = this

--- a/src/main/groovy/org/asciidoctor/groovydsl/extensions/DelegatingPostprocessor.groovy
+++ b/src/main/groovy/org/asciidoctor/groovydsl/extensions/DelegatingPostprocessor.groovy
@@ -22,7 +22,7 @@ class DelegatingPostprocessor extends Postprocessor {
 
     final Closure cl
     
-    DelegatingPostprocessor(Map options, Closure cl) {
+    DelegatingPostprocessor(Map options, @DelegatesTo(Postprocessor) Closure cl) {
         super(options)
         this.cl = cl
         cl.delegate = this

--- a/src/main/groovy/org/asciidoctor/groovydsl/extensions/DelegatingPreprocessor.groovy
+++ b/src/main/groovy/org/asciidoctor/groovydsl/extensions/DelegatingPreprocessor.groovy
@@ -23,7 +23,7 @@ class DelegatingPreprocessor extends Preprocessor {
 
     private final Closure cl
 
-    DelegatingPreprocessor(Map options, Closure cl) {
+    DelegatingPreprocessor(Map options, @DelegatesTo(Preprocessor) Closure cl) {
         super(options)
         this.cl = cl
         cl.delegate = this

--- a/src/main/groovy/org/asciidoctor/groovydsl/extensions/DelegatingTreeprocessor.groovy
+++ b/src/main/groovy/org/asciidoctor/groovydsl/extensions/DelegatingTreeprocessor.groovy
@@ -22,7 +22,7 @@ class DelegatingTreeprocessor extends Treeprocessor {
 
     private final Closure cl
 
-    DelegatingTreeprocessor(Map options, Closure cl) {
+    DelegatingTreeprocessor(Map options, @DelegatesTo(Treeprocessor) Closure cl) {
         super(options)
         this.cl = cl
         cl.delegate = this


### PR DESCRIPTION
As discussed in #5 this PR includes the use of groovy's '@DelegatesTo' annotation to help IDEs with autocompletion.
It also includes:
- Some missing tests, included tests for currently deprecated methods
- Typo corrections: some calls in AsciidoctorExtensionHandler used wrong method names and some methods used a map to class the extension closure instead of just the actual closure.
