### PR TITLE
Migrate extensions to AsciidoctorJ 1.6.0-alpha.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ repositories {
 
 dependencies {
     compile 'org.codehaus.groovy:groovy-all:2.3.9'
-    compile 'org.asciidoctor:asciidoctorj:1.5.5'
+    compile 'org.asciidoctor:asciidoctorj:1.6.0-alpha.3'
 
     testCompile('org.spockframework:spock-core:1.0-groovy-2.3') {
         exclude group: 'org.codehaus.groovy', module: 'groovy-all'
@@ -53,6 +53,6 @@ artifacts {
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '2.14'
+    gradleVersion = '2.14.1'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=1.0.0-SNAPSHOT
+version=1.6.0-SNAPSHOT
 sourceCompatibility=1.6
 targetCompatibility=1.6

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip

--- a/src/main/groovy/org/asciidoctor/groovydsl/extensions/DelegatingBlockMacroProcessor.groovy
+++ b/src/main/groovy/org/asciidoctor/groovydsl/extensions/DelegatingBlockMacroProcessor.groovy
@@ -15,7 +15,7 @@
  */
 package org.asciidoctor.groovydsl.extensions
 
-import org.asciidoctor.ast.AbstractBlock
+import org.asciidoctor.ast.StructuralNode
 import org.asciidoctor.extension.BlockMacroProcessor
 
 class DelegatingBlockMacroProcessor extends BlockMacroProcessor {
@@ -28,7 +28,7 @@ class DelegatingBlockMacroProcessor extends BlockMacroProcessor {
         cl.delegate = this
     }
     
-    Object process(AbstractBlock parent, String target, Map<String, Object> attributes) {
+    Object process(StructuralNode parent, String target, Map<String, Object> attributes) {
         cl.call(parent, target, attributes)
     }
 

--- a/src/main/groovy/org/asciidoctor/groovydsl/extensions/DelegatingBlockProcessor.groovy
+++ b/src/main/groovy/org/asciidoctor/groovydsl/extensions/DelegatingBlockProcessor.groovy
@@ -15,7 +15,7 @@
  */
 package org.asciidoctor.groovydsl.extensions
 
-import org.asciidoctor.ast.AbstractBlock
+import org.asciidoctor.ast.StructuralNode
 import org.asciidoctor.extension.BlockProcessor
 import org.asciidoctor.extension.Reader
 import org.asciidoctor.groovydsl.AsciidoctorExtensionHandler
@@ -30,7 +30,7 @@ class DelegatingBlockProcessor extends BlockProcessor {
         cl.delegate = this
     }
 
-    Object process(AbstractBlock parent, Reader reader, Map<String, Object> attributes) {
+    Object process(StructuralNode parent, Reader reader, Map<String, Object> attributes) {
         cl.call(parent, reader, attributes)
     }
 

--- a/src/main/groovy/org/asciidoctor/groovydsl/extensions/DelegatingIncludeProcessor.groovy
+++ b/src/main/groovy/org/asciidoctor/groovydsl/extensions/DelegatingIncludeProcessor.groovy
@@ -15,7 +15,7 @@
  */
 package org.asciidoctor.groovydsl.extensions
 
-import org.asciidoctor.ast.DocumentRuby
+import org.asciidoctor.ast.Document
 import org.asciidoctor.extension.IncludeProcessor
 import org.asciidoctor.extension.PreprocessorReader
 
@@ -32,10 +32,12 @@ class DelegatingIncludeProcessor extends IncludeProcessor {
         cl.delegate = this
         
     }
+
     boolean handles(String target) {
         filter.call(target)
     }
-    void process(DocumentRuby document, PreprocessorReader reader, String target, Map<String, Object> attributes) {
+
+    void process(Document document, PreprocessorReader reader, String target, Map<String, Object> attributes) {
         cl.call(document, reader, target, attributes)
     }
 

--- a/src/main/groovy/org/asciidoctor/groovydsl/extensions/DelegatingInlineMacroProcessor.groovy
+++ b/src/main/groovy/org/asciidoctor/groovydsl/extensions/DelegatingInlineMacroProcessor.groovy
@@ -15,7 +15,7 @@
  */
 package org.asciidoctor.groovydsl.extensions
 
-import org.asciidoctor.ast.AbstractBlock
+import org.asciidoctor.ast.ContentNode
 import org.asciidoctor.extension.InlineMacroProcessor
 
 class DelegatingInlineMacroProcessor extends InlineMacroProcessor {
@@ -28,7 +28,7 @@ class DelegatingInlineMacroProcessor extends InlineMacroProcessor {
         cl.delegate = this
     }
 
-    Object process(AbstractBlock parent, String target, Map<String, Object> attributes) {
+    Object process(ContentNode parent, String target, Map<String, Object> attributes) {
         cl.call(parent, target, attributes)
     }
 

--- a/src/main/groovy/org/asciidoctor/groovydsl/extensions/DelegatingPreprocessor.groovy
+++ b/src/main/groovy/org/asciidoctor/groovydsl/extensions/DelegatingPreprocessor.groovy
@@ -29,7 +29,7 @@ class DelegatingPreprocessor extends Preprocessor {
         cl.delegate = this
     }
 
-    PreprocessorReader process(Document document, PreprocessorReader reader) {
+    void process(Document document, PreprocessorReader reader) {
         cl.call(document, reader)
     }
 	

--- a/src/test/groovy/org/asciidoctor/groovydsl/AsciidoctorGroovyDSLSpec.groovy
+++ b/src/test/groovy/org/asciidoctor/groovydsl/AsciidoctorGroovyDSLSpec.groovy
@@ -218,7 +218,7 @@ blacklisted is a blacklisted word.
                     String content = """<div class="content">
 <script src="https://gist.github.com/${target}.js"></script>
 </div>"""
-                    createBlock(parent, "pass", [content], attributes, config);
+                    createBlock(parent, "pass", [content], attributes)
             }
         }
 
@@ -247,7 +247,7 @@ blacklisted is a blacklisted word.
             inline_macro('man') {
                 parent, target, attributes ->
                     def options = ["type": ":link", "target": target + ".html"]
-                    createInline(parent, "anchor", target, attributes, options).convert()
+                    createPhraseNode(parent, "anchor", target, attributes, options).convert()
             }
         }
 
@@ -319,7 +319,7 @@ World''',
                             .tokenize('_')
                             .collect { it.capitalize() }
                             .join(' ')
-                    createBlock(parent, 'pass', [capitalLines], attributes, config)
+                    createBlock(parent, 'pass', [capitalLines], attributes)
             }
         }
 
@@ -344,7 +344,7 @@ World''',
                             .tokenize('_')
                             .collect { it.capitalize() }
                             .join(' ')
-                    createBlock(parent, 'pass', [capitalLines], attributes, config)
+                    createBlock(parent, 'pass', [capitalLines], attributes)
             }
         }
 
@@ -366,7 +366,7 @@ World''',
             inlinemacro(name: 'man') {
                 parent, target, attributes ->
                     def options = ["type": ":link", "target": target + ".html"]
-                    createInline(parent, "anchor", target, attributes, options).convert()
+                    createPhraseNode(parent, "anchor", target, attributes, options).convert()
             }
         }
 
@@ -387,7 +387,7 @@ World''',
             inlinemacro('man') {
                 parent, target, attributes ->
                     def options = ["type": ":link", "target": target + ".html"]
-                    createInline(parent, "anchor", target, attributes, options).convert()
+                    createPhraseNode(parent, "anchor", target, attributes, options).convert()
             }
         }
 

--- a/src/test/resources/testblockmacroextension.groovy
+++ b/src/test/resources/testblockmacroextension.groovy
@@ -3,6 +3,6 @@ block_macro (name: "gist") {
     String content = """<div class="content"> 
 <script src="https://gist.github.com/${target}.js"></script> 
 </div>"""
-    createBlock(parent, "pass", [content], attributes, config);
+    createBlock(parent, "pass", [content], attributes);
 }
 

--- a/src/test/resources/testinlinemacroprocessorextension.groovy
+++ b/src/test/resources/testinlinemacroprocessorextension.groovy
@@ -1,5 +1,5 @@
 inline_macro (name: "man") {
     parent, target, attributes ->
     options=["type": ":link", "target": target + ".html"]
-    createInline(parent, "anchor", target, attributes, options).render()
+    createPhraseNode(parent, "anchor", target, attributes, options).render()
 }

--- a/src/test/resources/testtreeprocessorextension.groovy
+++ b/src/test/resources/testtreeprocessorextension.groovy
@@ -1,7 +1,7 @@
 treeprocessor {
     document ->
-    List blocks = document.blocks()
-    (0..<blocks.length).each {
+    def blocks = document.blocks()
+    (0..<blocks.size()).each {
         def block = blocks[it]
         def lines = block.lines()
         if (lines.size() > 0 && lines[0].startsWith('$')) {


### PR DESCRIPTION
Moves the Groovy DSL to work on top of AsciidoctorJ 1.6.0-alpha.3