### PR TITLE
remove deprecated methods

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,12 +13,22 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 
 == Unreleased
 
-Build::
-
-Documentation::
-
-Bug Fixes::
+This version is the graduation of the previous 1.6.0-alpha.1 branch making it compatible with the latest improvements from Asciidoctorj v2.2.0.
+Note that extensions using version 1.0.0.preview2 may not be compatible.
 
 Improvements::
 
+* Allow AsciidoctorExtensions to be instantiated (https://github.com/ysb33r[@ysb33r]) (https://github.com/asciidoctor/asciidoctorj-groovy-dsl/issues/18[#18])
+* Upgrade to Asciidoctorj v2.2.0 (https://github.com/abelsromero[@abelsromero]) (https://github.com/asciidoctor/asciidoctorj-groovy-dsl/pull/24[#24]).
+Continuation of the previous work of https://github.com/robertpanzer[@robertpanzer] in https://github.com/asciidoctor/asciidoctorj-groovy-dsl/pull/21[#21] and https://github.com/asciidoctor/asciidoctorj-groovy-dsl/pull/22[#22]
+* Removed deprecated methods `blockmacro`, `includeprocessor`, `inlinemacro`. Use the following instead: `block_macro`, `include_processor`, `inline_macro` (https://github.com/abelsromero[@abelsromero]) (https://github.com/asciidoctor/asciidoctorj-groovy-dsl/pull/27[#27])
 
+Bug Fixes::
+
+Documentation::
+
+* Fix artifact version in README examples (https://github.com/gtoast[@gtoast]) (https://github.com/asciidoctor/asciidoctorj-groovy-dsl/pull/16[#16])
+
+Build::
+
+* Upgrade Gradle to v5.6.4 to support building with Java versions superior to 8 (https://github.com/abelsromero[@abelsromero]) (https://github.com/asciidoctor/asciidoctorj-groovy-dsl/pull/25[#25])

--- a/src/main/groovy/org/asciidoctor/groovydsl/AsciidoctorExtensionHandler.groovy
+++ b/src/main/groovy/org/asciidoctor/groovydsl/AsciidoctorExtensionHandler.groovy
@@ -70,20 +70,6 @@ class AsciidoctorExtensionHandler {
         block_macro([(OPTION_NAME): name], cl)
     }
 
-    /**
-     * @deprecated Please use {@link #block_macro(java.util.Map, groovy.lang.Closure)} instead
-     */
-    void blockmacro(Map options, @DelegatesTo(BlockMacroProcessor) Closure cl) {
-        block_macro(options, cl)
-    }
-
-    /**
-     * @deprecated Please use {@link #block_macro(java.lang.String, groovy.lang.Closure)} instead
-     */
-    void blockmacro(String name, @DelegatesTo(BlockMacroProcessor) Closure cl) {
-        block_macro([(OPTION_NAME): name], cl)
-    }
-
     void postprocessor(Map options=[:], @DelegatesTo(Postprocessor) Closure cl) {
         asciidoctor.javaExtensionRegistry().postprocessor(new DelegatingPostprocessor(options, cl))
     }
@@ -98,34 +84,11 @@ class AsciidoctorExtensionHandler {
         asciidoctor.javaExtensionRegistry().includeProcessor(new DelegatingIncludeProcessor(optionsWithoutFilter, filter, cl))
     }
 
-    /**
-     * @deprecated Please use {@link #include_processor(java.util.Map, groovy.lang.Closure)} instead
-     */
-    void includeprocessor(Map options=[:], @DelegatesTo(IncludeProcessor) Closure cl) {
-        Closure filter = options[(OPTION_FILTER)]
-        Map optionsWithoutFilter = options - options.subMap([OPTION_FILTER])
-        asciidoctor.javaExtensionRegistry().includeProcessor(new DelegatingIncludeProcessor(optionsWithoutFilter, filter, cl))
-    }
-
     void inline_macro(Map options, @DelegatesTo(InlineMacroProcessor) Closure cl) {
         asciidoctor.javaExtensionRegistry().inlineMacro(new DelegatingInlineMacroProcessor(options[OPTION_NAME], options, cl))
     }
 
     void inline_macro(String macroName, @DelegatesTo(InlineMacroProcessor) Closure cl) {
-        inline_macro([(OPTION_NAME): macroName], cl)
-    }
-
-    /**
-     * @deprecated Please use {@link #inline_macro(java.util.Map, groovy.lang.Closure)} instead
-     */
-    void inlinemacro(Map options, @DelegatesTo(InlineMacroProcessor) Closure cl) {
-        asciidoctor.javaExtensionRegistry().inlineMacro(new DelegatingInlineMacroProcessor(options[OPTION_NAME], options, cl))
-    }
-
-    /**
-     * @deprecated Please use {@link #inline_macro(java.lang.String, groovy.lang.Closure)} instead
-     */
-    void inlinemacro(String macroName, @DelegatesTo(InlineMacroProcessor) Closure cl) {
         inline_macro([(OPTION_NAME): macroName], cl)
     }
 

--- a/src/test/resources/testdocinfoprocessorextension.groovy
+++ b/src/test/resources/testdocinfoprocessorextension.groovy
@@ -1,0 +1,5 @@
+String metatag = '<meta name="hello" content="world">'
+
+docinfo_processor {
+    document -> metatag
+}


### PR DESCRIPTION
This PR removes the deprecated methods no longer supported.
Also adds some missing test cases (markes as "New" in the table):

![image](https://user-images.githubusercontent.com/5781153/71784097-c068bc00-2fef-11ea-8723-e532d129952c.png)


For when the changelog is added:
_Removed deprecated methods `blockmacro`, `includeprocessor`, `inlinemacro`. Use the following instead: `blockmacro`, `includeprocessor`, `inlinemacro`._




NOTE: when the changlelog is added, I want to add a note