### PR TITLE
Fixes #31. Make sure that the attribute org.gradle.jvm.version is set…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,3 +70,6 @@ java {
     withSourcesJar()
 }
 
+compileJava {
+    options.release = 8
+}


### PR DESCRIPTION
… to 8 in the Gradle module descriptor

Thank you for opening a pull request and contributing to AsciidoctorJ Groovy DSL!

Please take a bit of time giving some details about your pull request:

## Kind of change

- [x] Bug fix
- [ ] New non-breaking feature
- [ ] New breaking feature
- [ ] Documentation update
- [ ] Build improvement

## Description

What is the goal of this pull request?

As I apparently built the last release of asciidoctorj-groovy-dsl with Java 15, the "Gradle module descriptor" now assumes that the jar is only compatible with Java 15 as it contains the attribute org.gradle.jvm.version with the value 15.
This PR fixes that and sets it to 8.

How does it achieve that?

The attribute is set explicitly to 8.

Are there any alternative ways to implement this?

Yes, I could make sure that I always build the project with Java 8.

Are there any implications of this pull request? Anything a user must know?

## Issue

If this PR fixes an open issue, please add a line of the form:

Fixes #Issue 


## Release notes

Please add a corresponding entry to the file CHANGELOG.adoc